### PR TITLE
Run Jest in Node environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
 			"pre-commit": "lint-staged"
 		}
 	},
+	"jest": {
+		"testEnvironment": "node"
+	},
 	"engines": {
 		"node": ">=10"
 	}


### PR DESCRIPTION
By default, Jest runs in an environment where a DOM is available (via
js-dom). Since this package is Node-only, make sure tests are ran in a
real node environment without any browser stuff.