### PR TITLE
Update fondue engine, drop Node 10 support following fondue engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -2381,8 +2381,8 @@
 			"dev": true
 		},
 		"fondue": {
-			"version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#e2e3e4396d12ec6e401f30a51483c1e87e3b5587",
-			"from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#master"
+			"version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#705fc3f9d32c9cf8500fe89ff9c2b990eadc6e5d",
+			"from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#705fc3f9d32c9cf8500fe89ff9c2b990eadc6e5d"
 		},
 		"for-in": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	},
 	"dependencies": {
 		"commander": "^6.1.0",
-		"fondue": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#master"
+		"fondue": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#705fc3f9d32c9cf8500fe89ff9c2b990eadc6e5d"
 	},
 	"lint-staged": {
 		"*.{js,cjs,mjs,json,md}": [
@@ -50,6 +50,6 @@
 		"testEnvironment": "node"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=12"
 	}
 }


### PR DESCRIPTION
Also, lock down the specific engine commit in package.json.
NPM installs the latest `master` version in some cases, even if a
specific commit was locked in `package-lock.json` :-(