### PR TITLE
Publish beta package

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-process-exit */
 const { program } = require("commander");
-const loadFondue = require("fondue");
+const loadFondue = require("@wakamai-fondue/engine");
 const packageJson = require("./package.json");
 const { stdout } = require("process");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wakamai-fondue-cli",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "wakamai-fondue-cli",
+	"name": "@wakamai-fondue/cli",
 	"version": "1.0.0-beta.2",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -889,6 +889,10 @@
 					"dev": true
 				}
 			}
+		},
+		"@wakamai-fondue/engine": {
+			"version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#eeb75565757d5243803adb129b46f38ac997e92d",
+			"from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#eeb75565757d5243803adb129b46f38ac997e92d"
 		},
 		"abab": {
 			"version": "2.0.4",
@@ -2379,10 +2383,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
-		},
-		"fondue": {
-			"version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#705fc3f9d32c9cf8500fe89ff9c2b990eadc6e5d",
-			"from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#705fc3f9d32c9cf8500fe89ff9c2b990eadc6e5d"
 		},
 		"for-in": {
 			"version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wakamai-fondue/cli",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wakamai-fondue-cli",
-	"version": "1.0.0",
+	"version": "1.0.0-beta.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wakamai-fondue/cli",
-	"version": "1.0.0-beta.3",
+	"version": "1.0.0-beta.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,16 @@
 		"README.md"
 	],
 	"keywords": [
-		"opentype",
 		"font",
-		"typography"
+		"truetype",
+		"opentype",
+		"typography",
+		"variable fonts",
+		"otf",
+		"ttf",
+		"woff",
+		"woff2",
+		"css"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"wakamai-fondue": "./cli.js"
 	},
 	"files": [
-		"cli.js"
+		"cli.js",
+		"README.md"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
 		"cli.js",
 		"README.md"
 	],
+	"keywords": [
+		"opentype",
+		"font",
+		"typography"
+	],
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-cli.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wakamai-fondue/cli",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.3",
 	"description": "",
 	"scripts": {
 		"test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wakamai-fondue/cli",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.2",
 	"description": "",
 	"scripts": {
 		"test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wakamai-fondue/cli",
-	"version": "1.0.0-beta.3",
+	"version": "1.0.0-beta.4",
 	"description": "",
 	"scripts": {
 		"test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wakamai-fondue/cli",
-	"version": "1.0.0-beta.0",
+	"version": "1.0.0-beta.1",
 	"description": "",
 	"scripts": {
 		"test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "wakamai-fondue-cli",
-	"version": "1.0.0",
+	"name": "@wakamai-fondue/cli",
+	"version": "1.0.0-beta.0",
 	"description": "",
 	"scripts": {
 		"test": "jest",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	},
 	"dependencies": {
 		"commander": "^6.1.0",
-		"fondue": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#705fc3f9d32c9cf8500fe89ff9c2b990eadc6e5d"
+		"@wakamai-fondue/engine": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#eeb75565757d5243803adb129b46f38ac997e92d"
 	},
 	"lint-staged": {
 		"*.{js,cjs,mjs,json,md}": [


### PR DESCRIPTION
(Note this is based on https://github.com/Wakamai-Fondue/wakamai-fondue-cli/pull/5, I'll rebase this PR when that is merged).

This PR makes a few changes to package.json in preparation for publication npm:

* Package name is changed to `@wakamai-fondue/cli`
* Keywords are added
* README is included in the package so it can be displayed on npmjs.com

See published (beta) package here: https://www.npmjs.com/package/@wakamai-fondue/cli
